### PR TITLE
fix: Update to a stable Gemini API model

### DIFF
--- a/server.js
+++ b/server.js
@@ -29,7 +29,7 @@ app.post('/api/generate', async (req, res) => {
       return res.status(400).json({ error: { message: 'Missing contents in request body' } });
     }
 
-    const model = process.env.GOOGLE_MODEL || 'gemini-2.5-flash-preview-05-20';
+    const model = process.env.GOOGLE_MODEL || 'gemini-1.5-flash-latest';
     const url = `https://generativelanguage.googleapis.com/v1beta/models/${model}:generateContent?key=${googleApiKey}`;
 
     const upstream = await fetch(url, {


### PR DESCRIPTION
The previous model `gemini-2.5-flash-preview-05-20` was a preview version and is no longer valid. This was causing the Google Generative Language API to return an HTML error page instead of a JSON response, leading to a JSON parsing error.

This change updates the model to `gemini-1.5-flash-latest`, which is a stable and supported model. This resolves the API error and allows the application to generate prompts successfully.