### PR TITLE
Fix: Improve history and light theme functionality

### DIFF
--- a/index.html
+++ b/index.html
@@ -107,6 +107,7 @@
             color: var(--text-color-secondary);
         }
         .light-theme .text-purple-200 { color: #6d28d9; }
+        .light-theme a.text-purple-400 { color: #6d28d9; }
         .light-theme a.text-purple-400:hover, .light-theme a.text-gray-300:hover { color: #5b21b6; }
         .light-theme header {
             background-color: rgba(255, 255, 255, 0.7);
@@ -640,7 +641,8 @@
                 copyBtn.classList.add('opacity-0');
                 promptOutput.textContent = "";
                 const generatedText = await callGemini(userRequest);
-                typeEffect(promptOutput, generatedText.trim(), () => {
+                const trimmedText = generatedText.trim();
+                typeEffect(promptOutput, trimmedText, () => {
                     copyBtn.classList.remove('opacity-0');
                     copyBtn.classList.add('transition-opacity', 'duration-500');
                 });
@@ -649,7 +651,7 @@
                 const items = loadHistory();
                 items.unshift({
                     userRequest,
-                    prompt: promptOutput.textContent,
+                    prompt: trimmedText,
                     framework: frameworkSelect.value,
                     tone: toneSelect.value,
                     length: lengthSelect.value,


### PR DESCRIPTION
This commit addresses two user-facing issues:

1.  **History Feature**: The history was not saving the generated prompts correctly. This was due to saving the prompt text from the DOM before the asynchronous typing animation could populate it. The fix is to save the generated text directly to localStorage, ensuring the full prompt is always captured.

2.  **Light Theme Readability**: In light mode, certain links had poor contrast, making them difficult to read. A CSS override has been added to use a darker, more accessible purple for these links, improving the overall visibility and user experience of the light theme.